### PR TITLE
Redirigir a `login` si no se tiene permisos

### DIFF
--- a/src/addProduct.php
+++ b/src/addProduct.php
@@ -5,7 +5,6 @@ require_once(__DIR__ . DIRECTORY_SEPARATOR . "bootstrap.php");
 
 use App\Utils\Route;
 use App\Controllers\ProductController;
-use App\Authorization\Authorization;
 
 $controller = new ProductController();
 $controller->add($_REQUEST['brandProduct'],$_REQUEST['nameProduct'],$_REQUEST['descriptionProduct']);

--- a/src/controllers/ProductController.php
+++ b/src/controllers/ProductController.php
@@ -14,12 +14,21 @@ class ProductController {
   }
 
   public function add($brand,$name, $description) {
+    $this->verify();
+
     $_SESSION['products'][$brand."-".$name] = array('brand'=>$brand,'name'=>$name,'description'=>$description);
     ksort($_SESSION['products']);
   }
 
   public function delete($key) {
-    unset($_SESSION['products'][$key]);
-  }  
+    $this->verify();
 
+    unset($_SESSION['products'][$key]);
+  }
+
+  private function verify() {
+    if (!$this->authorization->is_authorized()) {
+      throw new Exception("No puedes realizar esta acción.");
+    }
+  }
 }

--- a/src/controllers/RoutesController.php
+++ b/src/controllers/RoutesController.php
@@ -6,20 +6,31 @@ use \Exception;
 use App\Authorization\Authorization;
 use App\Utils\Route;
 
-class IndexController {
+class RoutesController {
   private $authorization;
 
   function __construct() {
     $this->authorization = new Authorization();
   }
 
-  public function handle_redirection() {
+  public function handle_redirection(string $route) {
     try {
       if (!$this->authorization->is_authorized()) {
         Route::redirect_to("login.php");
       }
 
-      Route::redirect_to("welcome.php");
+      Route::redirect_to($route);
+
+    } catch (\Exception $e) {
+      Route::redirect_to("login.php");
+    }
+  }
+
+  public function private_route() {
+    try {
+      if (!$this->authorization->is_authorized()) {
+        Route::redirect_to("login.php");
+      }
 
     } catch (\Exception $e) {
       Route::redirect_to("login.php");

--- a/src/deleteProduct.php
+++ b/src/deleteProduct.php
@@ -5,7 +5,6 @@ require_once(__DIR__ . DIRECTORY_SEPARATOR . "bootstrap.php");
 
 use App\Utils\Route;
 use App\Controllers\ProductController;
-use App\Authorization\Authorization;
 
 $controller = new ProductController();
 $controller->delete($_REQUEST['key']);

--- a/src/index.php
+++ b/src/index.php
@@ -2,7 +2,7 @@
 
 require_once(__DIR__ . DIRECTORY_SEPARATOR . "bootstrap.php");
 
-use App\Controllers\IndexController;
+use App\Controllers\RoutesController;
 
-$controller = new IndexController();
-$controller->handle_redirection();
+$controller = new RoutesController();
+$controller->handle_redirection("welcome.php");

--- a/src/products.php
+++ b/src/products.php
@@ -4,6 +4,11 @@
   require_once("./templates/dependencies.php");
   require_once("./templates/navigation.php");
   use App\Utils\Route;
+  use App\Controllers\RoutesController;
+
+  $controller = new RoutesController();
+  $controller->private_route();
+
   $delete = Route::get_route("deleteProduct.php");
 ?>
 <!DOCTYPE html>

--- a/src/welcome.php
+++ b/src/welcome.php
@@ -3,6 +3,11 @@
   require_once(__DIR__ . DIRECTORY_SEPARATOR . "bootstrap.php");
   require_once("./templates/dependencies.php");
   require_once("./templates/navigation.php");
+
+  use App\Controllers\RoutesController;
+
+  $controller = new RoutesController();
+  $controller->private_route();
 ?>
 <!DOCTYPE html>
 <html lang="es-MX" dir="ltr">


### PR DESCRIPTION
Ocurría un error al intentar acceder a `products` o `welcome` sin permisos necesarios, ahora se hace una redirección